### PR TITLE
fix(html/css-variables.md): CSS変数に追記した

### DIFF
--- a/docs/source/html/css-variables.md
+++ b/docs/source/html/css-variables.md
@@ -1,20 +1,23 @@
 # CSS変数したい
 
 ```css
-/* 変数を定義 */
---変数名: 値
+セレクタ {
 
-/* 変数を取得 */
-プロパティ名: var(--変数名)
+  /* 変数を定義 */
+  --変数名: 値
+
+  /* 変数を取得 */
+  プロパティ名: var(--変数名)
+}
 ```
 
-[カスタムプロパティ](https://developer.mozilla.org/ja/docs/Web/CSS/Using_CSS_custom_properties)を使って変数を宣言できます。
+[カスタムプロパティ](https://developer.mozilla.org/ja/docs/Web/CSS/Using_CSS_custom_properties)を使ってCSS変数を宣言できます。
 設定した変数の値は[var関数](https://developer.mozilla.org/ja/docs/Web/CSS/var)で取得できます。
 
 ```{note}
 
-いつのまにかCSSで変数が使えるようになっていました。
-mdnドキュメントは定期的に確認したほうがいいんだなと感じました。
+[Can I use](https://caniuse.com/css-variables)で調べると、CSS変数（カスタムプロパティ）は2017年後半に使えるようになっていました。
+以下のようにグローバル変数として使うのが便利だと思います。
 
 ```
 


### PR DESCRIPTION
- CSS変数（カスタムプロパティ）がいつから使えるようになっていたかを調べた