### PR TITLE
fix(docs/source/conf.py): deprecation warningを修正した

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -186,4 +186,4 @@ latex_show_urls = "footnote"
 # latex_domain_indices = True
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {"https://docs.python.org/": None}
+intersphinx_mapping = {"python": ("https://docs.python.org/", None)}


### PR DESCRIPTION
下記のwarningを修正した

> WARNING: The pre-Sphinx 1.0 'intersphinx_mapping' format is deprecated and will be removed in Sphinx 8. Update to the current format as described in the documentation. Hint: "intersphinx_mapping = {'<name>': ('https://docs.python.org/', None)}".https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_mapping


